### PR TITLE
fix a typo in i6_rgn.h

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ else
 fi
 
 if [ "$1" = "arm-glibc" ] || [ "$1" = "hisi-v4a" ]; then
-	toolchain toolchain.hisilicon-hi3516cv500 -lm
+	toolchain toolchain.hisilicon-hi3516cv500 arm -lm
 elif [ "$1" = "arm-musl3" ] || [ "$1" = "hisi-v2a" ] || [ "$1" = "hisi-v3a" ]; then
     toolchain toolchain.hisilicon-hi3516av100 arm
 elif [ "$1" = "arm-musl4" ] || [ "$1" = "hisi-v4" ]; then


### PR DESCRIPTION
The enumeration type i6_common_pixfmt should be i6_rgn_pixfmt in i6_rgn_cnf