### PR TITLE
Add exposure control API with fps coordination

### DIFF
--- a/src/app_config.c
+++ b/src/app_config.c
@@ -374,6 +374,7 @@ enum ConfigError parse_app_config(void) {
     if (err != CONFIG_OK)
         goto RET_ERR;
     parse_int(&ini, "isp", "antiflicker", -1, 60, &app_config.antiflicker);
+    parse_int(&ini, "isp", "exposure", 0, 500000, &app_config.exposure);
 
     parse_bool(&ini, "mdns", "enable", &app_config.mdns_enable);
 

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -41,6 +41,7 @@ struct AppConfig {
     bool mirror;
     bool flip;
     int antiflicker;
+    unsigned int exposure;
 
     // [osd]
     bool osd_enable;

--- a/src/hal/star/i6_hal.c
+++ b/src/hal/star/i6_hal.c
@@ -480,17 +480,40 @@ int i6_sensor_exposure(unsigned int micros)
 {
     int ret;
 
+    if (micros == 0) {
+        /* Restore auto-exposure: reset limits to wide range and restore fps */
+        i6_isp_exp config;
+        if (ret = i6_isp.fnGetExposureLimit(0, &config))
+            return ret;
+        config.minShutterUs = 0;
+        config.maxShutterUs = 333333;
+        if (ret = i6_isp.fnSetExposureLimit(0, &config))
+            return ret;
+        if (_i6_snr_framerate > 0)
+            i6_snr.fnSetFramerate(_i6_snr_index, _i6_snr_framerate);
+        return 0;
+    }
+
+    /* Reduce sensor fps if exposure requires it (frame time must exceed shutter) */
+    if (micros > 33333) {
+        unsigned int needed_fps = 1000000 / micros;
+        if (needed_fps < 3) needed_fps = 3;
+        if (ret = i6_snr.fnSetFramerate(_i6_snr_index, needed_fps))
+            return ret;
+    }
+
     {
         i6_isp_exp config;
         if (ret = i6_isp.fnGetExposureLimit(0, &config))
             return ret;
 
+        config.minShutterUs = micros;
         config.maxShutterUs = micros;
         if (ret = i6_isp.fnSetExposureLimit(0, &config))
             return ret;
     }
 
-    return ret;
+    return 0;
 }
 
 int i6_video_create(char index, hal_vidconfig *config)

--- a/src/media.c
+++ b/src/media.c
@@ -274,6 +274,16 @@ void set_grayscale(bool active) {
     pthread_mutex_unlock(&chnMtx);
 }
 
+int set_exposure(unsigned int micros) {
+    int ret = -1;
+    switch (plat) {
+#if defined(__ARM_PCS_VFP)
+        case HAL_PLATFORM_I6:  ret = i6_sensor_exposure(micros); break;
+#endif
+    }
+    return ret;
+}
+
 int take_next_free_channel(bool mainLoop) {
     pthread_mutex_lock(&chnMtx);
     for (int i = 0; i < chnCount; i++) {
@@ -530,6 +540,7 @@ int enable_mjpeg(void) {
         config.framerate = app_config.mjpeg_fps;
         config.bitrate = app_config.mjpeg_bitrate;
         config.maxBitrate = app_config.mjpeg_bitrate * 5 / 4;
+        config.minQual = config.maxQual = app_config.jpeg_qfactor;
 
         switch (plat) {
 #if defined(__ARM_PCS_VFP)
@@ -837,6 +848,16 @@ int start_sdk(void) {
             case HAL_PLATFORM_T31: t31_config_load(app_config.sensor_config); break;
 #endif
         }
+
+    if (app_config.exposure > 0) {
+        ret = set_exposure(app_config.exposure);
+        if (ret)
+            HAL_DANGER("media", "Failed to set exposure %uus: %#x\n",
+                app_config.exposure, ret);
+        else
+            HAL_INFO("media", "Fixed exposure set to %uus\n",
+                app_config.exposure);
+    }
 
     HAL_INFO("media", "SDK has started successfully!\n");
 

--- a/src/media.h
+++ b/src/media.h
@@ -29,6 +29,7 @@ int start_streaming(void);
 void stop_streaming(void);
 
 void request_idr(void);
+int set_exposure(unsigned int micros);
 void set_grayscale(bool active);
 int take_next_free_channel(bool mainLoop);
 

--- a/src/server.c
+++ b/src/server.c
@@ -1356,6 +1356,44 @@ void respond_request(http_request_t *req) {
         return;
     }
 
+    if (EQUALS(req->uri, "/api/exposure")) {
+        if (!EMPTY(req->query)) {
+            char *remain;
+            while (req->query) {
+                char *value = split(&req->query, "&");
+                if (!value || !*value) continue;
+                unescape_uri(value);
+                char *key = split(&value, "=");
+                if (!key || !*key || !value || !*value) continue;
+                if (EQUALS(key, "value")) {
+                    int result = strtol(value, &remain, 10);
+                    if (remain != value && result >= 0) {
+                        app_config.exposure = result;
+                        int ret = set_exposure(result);
+                        if (ret) {
+                            respLen = sprintf(response,
+                                "HTTP/1.1 500 Internal Server Error\r\n"
+                                "Content-Type: application/json;charset=UTF-8\r\n"
+                                "Connection: close\r\n"
+                                "\r\n"
+                                "{\"error\":\"set_exposure failed\",\"code\":%d}", ret);
+                            send_and_close(req->clntFd, response, respLen);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        respLen = sprintf(response,
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: application/json;charset=UTF-8\r\n"
+            "Connection: close\r\n"
+            "\r\n"
+            "{\"exposure\":%u}", app_config.exposure);
+        send_and_close(req->clntFd, response, respLen);
+        return;
+    }
+
     if (EQUALS(req->uri, "/api/status")) {
         struct sysinfo si;
         sysinfo(&si);


### PR DESCRIPTION
## Motivation

Enable fixed long-exposure control (up to 333ms) for machine vision use cases on SigmaStar infinity6e (SSC30KQ + IMX335). The existing `i6_sensor_exposure()` function was never wired up — this adds config, HTTP API, and automatic sensor fps coordination so long exposures work without stalling the video pipeline.

## Implementation

- Add `isp.exposure` config option (0=auto, or microseconds up to 500000) in `app_config.h`/`app_config.c`
- Enhance `i6_sensor_exposure()` in `i6_hal.c`: set both min and max shutter limits to force exact exposure, auto-reduce sensor fps via `MI_SNR_SetFps` for exposures >33ms, restore defaults when set to 0
- Add `set_exposure()` dispatch function in `media.c`/`media.h` following the `set_grayscale()` pattern
- Apply configured exposure after ISP init and sensor config load in `start_sdk()`
- Add `GET /api/exposure` HTTP endpoint in `server.c` for runtime read/set (query param `value`)
- Wire MJPEG encoder QP mode quality to `jpeg.qfactor` setting

Tested on SSC30KQ + IMX335: fixed exposure from 10ms to 333ms with live RTSP and MJPEG streaming, no VENC stalls.

---
🦌 claude-opus-4-6