### PR TITLE
rtsp: don't free the server handle while encoder threads still use it

### DIFF
--- a/src/rtsp/rtp.c
+++ b/src/rtsp/rtp.c
@@ -415,12 +415,19 @@ int rtp_send_h26x(rtsp_handle h, hal_vidstream *stream, char isH265)
     /* checkout RTP packet */
     DASSERT(h, return FAILURE);
 
-    if (gbl_get_quit(h->pool->sharedp->gbl)) {
+    /* Do not reach through h->pool to find out whether the server is gone:
+     * rtsp_finish() raises that quit flag and then deletes the threadpool it
+     * lives in, so the check itself read freed memory. h->finished lives in the
+     * handle, which rtsp_finish() now keeps alive for exactly this reason. */
+    rtsp_lock(h);
+    if (h->finished) {
+        rtsp_unlock(h);
 #ifdef DEBUG_RTSP
         ERR("server threads have gone already. call rtsp_finish()\n");
 #endif
         return FAILURE;
     }
+    rtsp_unlock(h);
 
     h->isH265 = isH265;
 
@@ -471,12 +478,16 @@ int rtp_send_mp3(rtsp_handle h, unsigned char *buf, size_t len)
     /* checkout RTP packet */
     DASSERT(h, return FAILURE);
 
-    if (gbl_get_quit(h->pool->sharedp->gbl)) {
+    /* See the note in rtp_send_h26x(). */
+    rtsp_lock(h);
+    if (h->finished) {
+        rtsp_unlock(h);
 #ifdef DEBUG_RTSP
         ERR("server threads have gone already. call rtsp_finish()\n");
 #endif
         return FAILURE;
     }
+    rtsp_unlock(h);
 
     h->audioPt = 14;
 

--- a/src/rtsp/rtsp.c
+++ b/src/rtsp/rtsp.c
@@ -838,6 +838,13 @@ void rtsp_finish(rtsp_handle h)
 {
     /* close every connections in the handle */
     if (h) {
+        /* Tell the encoder threads to stop reaching into this handle before any
+         * of it goes away. They call rtp_send_h26x()/rtp_send_mp3() from
+         * media.c, which is still running at this point. */
+        pthread_mutex_lock(&h->mutex);
+        h->finished = 1;
+        pthread_mutex_unlock(&h->mutex);
+
         list_destroy(&h->con_list);
 
         if (h->pool) {
@@ -854,11 +861,17 @@ void rtsp_finish(rtsp_handle h)
             mime_encoded_delete(h->sprop_pps_b64);
 
             threadpool_delete(h->pool);
+            h->pool = NULL;
         }
 
-        pthread_mutex_destroy(&h->mutex);
-
-        FREE(h);
+        /* Deliberately no pthread_mutex_destroy()/FREE(h) here. main.c calls
+         * rtsp_finish() well before sdk_stop() and never clears the rtspHandle
+         * global, so the encoder threads keep calling rtp_send_h26x() and
+         * rtp_send_mp3() with this pointer until the process exits; they need
+         * the mutex and the finished flag to stay valid in order to bail out.
+         * rtsp_create() runs once per process, so this costs a single small
+         * allocation that process exit reclaims. rtsp_create()'s own error path
+         * still frees the handle, where nothing can reach it yet. */
     }
 
     return;
@@ -897,7 +910,13 @@ rtsp_handle rtsp_create(unsigned char max_con, unsigned int port, int priority)
     return nh;
 
 error:
+    /* Nothing has published this handle yet, so unlike the shutdown path there
+     * is no encoder thread that could still dereference it. */
     rtsp_finish(nh);
+    if (nh) {
+        pthread_mutex_destroy(&nh->mutex);
+        FREE(nh);
+    }
     return NULL;
 }
 

--- a/src/rtsp/rtsp.h
+++ b/src/rtsp/rtsp.h
@@ -124,6 +124,10 @@ struct transfer_item_t {
 
 struct __rtsp_obj_t {
     pthread_mutex_t mutex;
+    /* Raised by rtsp_finish(). The encoder threads keep calling rtp_send_*()
+     * with this handle after that point, so it has to stay readable for the
+     * rest of the process lifetime. Guarded by mutex. */
+    char finished;
     struct list_head_t con_list;
     threadpool_handle pool;
     bufpool_handle con_pool;


### PR DESCRIPTION
## The bug

`rtsp_finish()` frees the server handle, but the encoder threads keep using it for a while afterwards.

`main.c` tears down in this order:

```
115:  rtsp_finish(rtspHandle);      <-- frees the handle
...
123:  region_stop();
126:  night_disable();
128:  sdk_stop();                   <-- encoder threads finally stop here
```

`rtspHandle` is never cleared, and `media.c` passes it straight into `rtp_send_h26x()` / `rtp_send_mp3()`. So every frame encoded between :115 and :128 dereferences freed memory.

The guard that should have caught this can't, because it lives in the memory it is checking:

```c
if (gbl_get_quit(h->pool->sharedp->gbl)) {   /* h and h->pool are already freed */
```

`rtsp_finish()` raises that quit flag and then calls `threadpool_delete(h->pool)` and `FREE(h)`. The check reads freed memory to decide whether the memory has been freed. `region_stop()` and `night_disable()` allocate in between, so the chunk gets reused, the check reads whatever now occupies that word, passes, and the sender goes on to `rtsp_lock(h)` on a destroyed mutex and `list_map_inline(&h->con_list, ...)` over a destroyed list.

`DASSERT(h, ...)` doesn't help — `h` is dangling, not NULL.

## The fix

Move the shutdown flag into the handle itself, and stop freeing the handle in `rtsp_finish()`:

- `struct __rtsp_obj_t` gains a `finished` flag, guarded by the existing mutex.
- `rtsp_finish()` raises it first, before releasing anything else.
- The two senders test `h->finished` instead of reaching through `h->pool`.
- `rtsp_finish()` no longer calls `pthread_mutex_destroy()` / `FREE(h)`, so a late sender always finds a valid mutex and a flag telling it to turn around.

Connections, buffer pools, MIME buffers and the threadpool are all still released exactly as before. What stays allocated is the handle struct itself. `rtsp_create()` runs once per process, so that's a single small allocation reclaimed at exit. `rtsp_create()`'s own error path frees it explicitly, since nothing can reach it there yet.

## Alternative worth considering

Calling `sdk_stop()` before `rtsp_finish()` in `main.c` would remove the hazardous window entirely and let the handle be freed normally. I didn't do that here because it changes shutdown ordering for every SoC and I can only test one — but if you'd prefer that shape, I'm happy to redo it.

## Testing

Found on an Infinity6E (ssc30kq) running under Frigate with two streams: a SIGTERM restart segfaulted essentially every time, the faulting address landing a few dozen bytes into the sender's connection-list walk on a junk pointer. The equivalent fix has been running clean on that hardware since.

Cross-compiled clean for `arm-openipc-linux-gnueabihf` with no new warnings. Only the ssc30kq path is hardware-tested; the change is SoC-independent but a second pair of eyes on another target would be welcome.

## Not addressed here

There's a narrower pre-existing race left in place: a sender that gets past the flag check can still be mid-send, holding transfer items, when `rtsp_finish()` deletes the pools. Closing it needs a drain barrier on the sender count. I left it out deliberately since I can't exercise it on this stack — happy to follow up separately if you want it.