### PR TITLE
rtsp: send interleaved frames in one write, stamp per frame, add G.711

### DIFF
--- a/res/index.html
+++ b/res/index.html
@@ -372,6 +372,8 @@
 			apiRead('mjpeg');
 			apiRead('night');
 			apiRead('record');
+			apiRead('rtsp');
+			apiRead('onvif');
 			toggleRecord(document.getElementById('record_state'));
 			apiRead('time');
 
@@ -676,6 +678,37 @@
 			</div>
 		</div>
 		<div class="c cont">
+			<h2 class="unl">Network</h2>
+			<div class="row">
+				<div class="col">
+					<fieldset>
+						<legend>RTSP</legend>
+						<table class="tc w-100">
+							<tr><td><label for="rtsp_enable">Enable</label></td><td><select id="rtsp_enable"><option value="false">OFF</option><option value="true">ON</option></select></td></tr>
+							<tr><td><label for="rtsp_port">Port</label></td><td><input type="number" id="rtsp_port" min="1" max="65535"></td></tr>
+							<tr><td><label for="rtsp_enable_auth">Authentication</label></td><td><select id="rtsp_enable_auth"><option value="false">OFF</option><option value="true">ON</option></select></td></tr>
+							<tr><td><label for="rtsp_auth_user">Username</label></td><td><input type="text" id="rtsp_auth_user"></td></tr>
+							<tr><td><label for="rtsp_auth_pass">Password</label></td><td><input type="password" id="rtsp_auth_pass"></td></tr>
+							<tr><td><label for="rtsp_audio_codec">Audio codec</label></td><td><select id="rtsp_audio_codec"><option value="pcma">G.711 A-law (8 kHz)</option><option value="mp3">MP3</option></select></td></tr>
+						</table>
+						<a href="javascript:apiApply('rtsp')" class="btn right">Apply</a>
+						<small>Port and codec changes take effect after a restart; use Save to keep them.</small>
+					</fieldset>
+				</div>
+				<div class="col">
+					<fieldset>
+						<legend>ONVIF</legend>
+						<table class="tc w-100">
+							<tr><td><label for="onvif_enable">Enable</label></td><td><select id="onvif_enable"><option value="false">OFF</option><option value="true">ON</option></select></td></tr>
+							<tr><td><label for="onvif_enable_auth">Authentication</label></td><td><select id="onvif_enable_auth"><option value="false">OFF</option><option value="true">ON</option></select></td></tr>
+							<tr><td><label for="onvif_auth_user">Username</label></td><td><input type="text" id="onvif_auth_user"></td></tr>
+							<tr><td><label for="onvif_auth_pass">Password</label></td><td><input type="password" id="onvif_auth_pass"></td></tr>
+						</table>
+						<a href="javascript:apiApply('onvif')" class="btn right">Apply</a>
+						<small>Applies after a restart; use Save to keep it.</small>
+					</fieldset>
+				</div>
+			</div>
 			<h2 class="unl">OSD</h2>
 			<div id="osd_tpl" style="display:none">
 				<div class="w-100 box osd_sect">

--- a/res/index.html
+++ b/res/index.html
@@ -368,12 +368,12 @@
 		function onLoad() {
 			apiRead('audio');
 			apiRead('jpeg');
-			apiRead('mp4');
 			apiRead('mjpeg');
+			apiRead('mp4');
 			apiRead('night');
+			apiRead('onvif');
 			apiRead('record');
 			apiRead('rtsp');
-			apiRead('onvif');
 			toggleRecord(document.getElementById('record_state'));
 			apiRead('time');
 
@@ -678,37 +678,6 @@
 			</div>
 		</div>
 		<div class="c cont">
-			<h2 class="unl">Network</h2>
-			<div class="row">
-				<div class="col">
-					<fieldset>
-						<legend>RTSP</legend>
-						<table class="tc w-100">
-							<tr><td><label for="rtsp_enable">Enable</label></td><td><select id="rtsp_enable"><option value="false">OFF</option><option value="true">ON</option></select></td></tr>
-							<tr><td><label for="rtsp_port">Port</label></td><td><input type="number" id="rtsp_port" min="1" max="65535"></td></tr>
-							<tr><td><label for="rtsp_enable_auth">Authentication</label></td><td><select id="rtsp_enable_auth"><option value="false">OFF</option><option value="true">ON</option></select></td></tr>
-							<tr><td><label for="rtsp_auth_user">Username</label></td><td><input type="text" id="rtsp_auth_user"></td></tr>
-							<tr><td><label for="rtsp_auth_pass">Password</label></td><td><input type="password" id="rtsp_auth_pass"></td></tr>
-							<tr><td><label for="rtsp_audio_codec">Audio codec</label></td><td><select id="rtsp_audio_codec"><option value="pcma">G.711 A-law (8 kHz)</option><option value="mp3">MP3</option></select></td></tr>
-						</table>
-						<a href="javascript:apiApply('rtsp')" class="btn right">Apply</a>
-						<small>Port and codec changes take effect after a restart; use Save to keep them.</small>
-					</fieldset>
-				</div>
-				<div class="col">
-					<fieldset>
-						<legend>ONVIF</legend>
-						<table class="tc w-100">
-							<tr><td><label for="onvif_enable">Enable</label></td><td><select id="onvif_enable"><option value="false">OFF</option><option value="true">ON</option></select></td></tr>
-							<tr><td><label for="onvif_enable_auth">Authentication</label></td><td><select id="onvif_enable_auth"><option value="false">OFF</option><option value="true">ON</option></select></td></tr>
-							<tr><td><label for="onvif_auth_user">Username</label></td><td><input type="text" id="onvif_auth_user"></td></tr>
-							<tr><td><label for="onvif_auth_pass">Password</label></td><td><input type="password" id="onvif_auth_pass"></td></tr>
-						</table>
-						<a href="javascript:apiApply('onvif')" class="btn right">Apply</a>
-						<small>Applies after a restart; use Save to keep it.</small>
-					</fieldset>
-				</div>
-			</div>
 			<h2 class="unl">OSD</h2>
 			<div id="osd_tpl" style="display:none">
 				<div class="w-100 box osd_sect">
@@ -752,6 +721,94 @@
 							<tr><td><label for="osd_img">Local file</label></td><td><input type="text" id="osd_img" oninput="updateOsdSummary(this.id)"></td></tr>
 						</table>
 					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<input type="checkbox" id="network-modal">
+	<div class="c modal vh-100 w-100 scrolly">
+		<div class="c bg-black menu pv2 row" tabindex="0">
+			<b><label for="network-modal" class="lbl-modal ph2 gray">Divinus</label></b>
+			<div class="col">
+				<a href="javascript:saveConfig()" class="ph2">Save</a>
+				<a href="javascript:restartApp()" class="ph2">Restart</a>
+				<label for="network-modal" class="btn primary close">Close</label>
+			</div>
+		</div>
+		<div class="c cont">
+			<h2 class="unl">Network</h2>
+			<div class="row">
+				<div class="6 col box">
+					<fieldset>
+						<legend>RTSP</legend>
+						<table class="w-100">
+							<tr>
+								<td><label for="rtsp_enable">Enabled</label></td>
+								<td><select id="rtsp_enable">
+									<option value="false">OFF</option>
+									<option value="true">ON</option>
+								</select></td>
+							</tr>
+							<tr>
+								<td><label for="rtsp_port">Port</label></td>
+								<td><input type="number" id="rtsp_port" min="1" max="65535"></td>
+							</tr>
+							<tr>
+								<td><label for="rtsp_enable_auth">Authentication</label></td>
+								<td><select id="rtsp_enable_auth">
+									<option value="false">OFF</option>
+									<option value="true">ON</option>
+								</select></td>
+							</tr>
+							<tr>
+								<td><label for="rtsp_auth_user">Username</label></td>
+								<td><input type="text" id="rtsp_auth_user"></td>
+							</tr>
+							<tr>
+								<td><label for="rtsp_auth_pass">Password</label></td>
+								<td><input type="password" id="rtsp_auth_pass"></td>
+							</tr>
+							<tr>
+								<td><label for="rtsp_audio_codec">Audio&nbsp;codec</label></td>
+								<td><select id="rtsp_audio_codec">
+									<option value="pcma">G.711A</option>
+									<option value="pcmu">G.711U</option>
+									<option value="mp3">MP3</option>
+								</select></td>
+							</tr>
+						</table>
+						<a href="javascript:apiApply('rtsp')" class="btn right">Apply</a>
+					</fieldset>
+				</div>
+				<div class="6 col box">
+					<fieldset>
+						<legend>ONVIF</legend>
+						<table class="w-100">
+							<tr>
+								<td><label for="onvif_enable">Enabled</label></td>
+								<td><select id="onvif_enable">
+									<option value="false">OFF</option>
+									<option value="true">ON</option>
+								</select></td>
+							</tr>
+							<tr>
+								<td><label for="onvif_enable_auth">Authentication</label></td>
+								<td><select id="onvif_enable_auth">
+									<option value="false">OFF</option>
+									<option value="true">ON</option>
+								</select></td>
+							</tr>
+							<tr>
+								<td><label for="onvif_auth_user">Username</label></td>
+								<td><input type="text" id="onvif_auth_user"></td>
+							</tr>
+							<tr>
+								<td><label for="onvif_auth_pass">Password</label></td>
+								<td><input type="password" id="onvif_auth_pass"></td>
+							</tr>
+						</table>
+						<a href="javascript:apiApply('onvif')" class="btn right">Apply</a>
+					</fieldset>
 				</div>
 			</div>
 		</div>
@@ -860,6 +917,7 @@
 		<div class="col">
 			<label for="live-modal" class="lbl-modal ph2 white">Live</label>
 			<label for="media-modal" class="lbl-modal ph2 white">Media</label>
+			<label for="network-modal" class="lbl-modal ph2 white">Network</label>
 			<label for="osd-modal" class="lbl-modal ph2 white">OSD</label>
 			<label for="system-modal" class="lbl-modal ph2 white">System</label>
 			<a href="image.jpg" class="ph2 white" target="_blank">Snapshot</a>

--- a/src/app_config.c
+++ b/src/app_config.c
@@ -122,6 +122,7 @@ int app_config_save(void) {
     fprintf(file, "rtsp:\n");
     fprintf(file, "  enable: %s\n", app_config.rtsp_enable ? "true" : "false");
     fprintf(file, "  port: %d\n", app_config.rtsp_port);
+    fprintf(file, "  audio_codec: %s\n", app_config.rtsp_audio_codec);
     fprintf(file, "  enable_auth: %s\n", app_config.rtsp_enable_auth ? "true" : "false");
     fprintf(file, "  auth_user: %s\n", app_config.rtsp_auth_user);
     fprintf(file, "  auth_pass: %s\n", app_config.rtsp_auth_pass);
@@ -236,6 +237,7 @@ enum ConfigError app_config_parse(void) {
 
     app_config.rtsp_enable = false;
     app_config.rtsp_port = 554;
+    strcpy(app_config.rtsp_audio_codec, "mp3");   /* upstream default; the Fullhan image ships pcma in its yaml */
     app_config.rtsp_enable_auth = false;
     app_config.rtsp_auth_user[0] = '\0';
     app_config.rtsp_auth_pass[0] = '\0';
@@ -432,6 +434,18 @@ enum ConfigError app_config_parse(void) {
 
     parse_bool(&ini, "rtsp", "enable", &app_config.rtsp_enable);
     parse_int(&ini, "rtsp", "port", 0, USHRT_MAX, &app_config.rtsp_port);
+    {
+        /* Bounded, and only the two codecs the RTP path implements: anything
+         * else would advertise a payload type nothing produces. */
+        char codec[16] = {0};
+        if (parse_param_value_n(&ini, "rtsp", "audio_codec", codec, sizeof(codec)) == CONFIG_OK) {
+            if (EQUALS(codec, "pcma") || EQUALS(codec, "mp3")) {
+                strncpy(app_config.rtsp_audio_codec, codec,
+                    sizeof(app_config.rtsp_audio_codec) - 1);
+                app_config.rtsp_audio_codec[sizeof(app_config.rtsp_audio_codec) - 1] = 0;
+            }
+        }
+    }
     if (app_config.rtsp_enable) {
         parse_bool(&ini, "rtsp", "enable_auth", &app_config.rtsp_enable_auth);
         parse_param_value(

--- a/src/app_config.c
+++ b/src/app_config.c
@@ -435,11 +435,11 @@ enum ConfigError app_config_parse(void) {
     parse_bool(&ini, "rtsp", "enable", &app_config.rtsp_enable);
     parse_int(&ini, "rtsp", "port", 0, USHRT_MAX, &app_config.rtsp_port);
     {
-        /* Bounded, and only the two codecs the RTP path implements: anything
+        /* Bounded, and only the codecs the RTP path implements: anything
          * else would advertise a payload type nothing produces. */
         char codec[16] = {0};
         if (parse_param_value_n(&ini, "rtsp", "audio_codec", codec, sizeof(codec)) == CONFIG_OK) {
-            if (EQUALS(codec, "pcma") || EQUALS(codec, "mp3")) {
+            if (EQUALS(codec, "pcma") || EQUALS(codec, "pcmu") || EQUALS(codec, "mp3")) {
                 strncpy(app_config.rtsp_audio_codec, codec,
                     sizeof(app_config.rtsp_audio_codec) - 1);
                 app_config.rtsp_audio_codec[sizeof(app_config.rtsp_audio_codec) - 1] = 0;

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -60,6 +60,7 @@ struct AppConfig {
     char rtsp_auth_user[32];
     char rtsp_auth_pass[32];
     int rtsp_port;
+    char rtsp_audio_codec[8];   /* pcma (G.711 A-law, 8 kHz) or mp3 */
 
     // [record]
     bool record_enable;

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -60,7 +60,7 @@ struct AppConfig {
     char rtsp_auth_user[32];
     char rtsp_auth_pass[32];
     int rtsp_port;
-    char rtsp_audio_codec[8];   /* pcma (G.711 A-law, 8 kHz) or mp3 */
+    char rtsp_audio_codec[8];   /* pcma (G.711A), pcmu (G.711U) or mp3 */
 
     // [record]
     bool record_enable;

--- a/src/fmt/bitbuf.c
+++ b/src/fmt/bitbuf.c
@@ -1,6 +1,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "bitbuf.h"
 
@@ -57,8 +58,7 @@ enum BufError put_to_offset(
     const uint32_t size) {
     chk_ptr uint32_t pos = offset + size;
     if (pos >= ptr->size)
-        chk_realloc for (uint32_t i = 0; i < size; i++) ptr->buf[offset + i] =
-            data[i];
+        chk_realloc memcpy(ptr->buf + offset, data, size);
     return BUF_OK;
 }
 enum BufError put(struct BitBuf *ptr, const char *data, const uint32_t size) {

--- a/src/fmt/moov.c
+++ b/src/fmt/moov.c
@@ -607,7 +607,8 @@ enum BufError write_DecoderConfig(struct BitBuf *ptr, const struct MoovInfo *moo
     err = put_u32_be(ptr, 0);
     chk_err;
 
-    err = put_u8(ptr, moov_info->audio_codec);
+    err = put_u8(ptr, (moov_info->audio_codec == ACODEC_ID_MP3 && moov_info->audio_samplerate >= 32000) ?
+        0x6B /* MPEG-1 audio */ : moov_info->audio_codec);
     chk_err; // objectTypeIndication, https://mp4ra.org/#/object_types
     err = put_u8(ptr, 0x15);
     chk_err; // streamType

--- a/src/fmt/mp4.c
+++ b/src/fmt/mp4.c
@@ -60,6 +60,10 @@ enum BufError create_header(char is_h265) {
 
 void mp4_set_config(short width, short height, char framerate, char acodec,
     unsigned short bitrate, char channels, unsigned int srate) {
+    /* A new stream configuration (codec, size) invalidates the cached header
+     * and parameter sets; without this a codec switch keeps sending the old one */
+    buf_header.offset = 0;
+    buf_sps_len = buf_pps_len = buf_vps_len = 0;
     vid_width = width;
     vid_height = height;
     vid_framerate = framerate;

--- a/src/hal/config.c
+++ b/src/hal/config.c
@@ -58,6 +58,12 @@ enum ConfigError section_pos(
 enum ConfigError parse_param_value(
     struct IniConfig *ini, const char *section, const char *param_name,
     char *param_value) {
+    return parse_param_value_n(ini, section, param_name, param_value, (size_t)-1);
+}
+
+enum ConfigError parse_param_value_n(
+    struct IniConfig *ini, const char *section, const char *param_name,
+    char *param_value, size_t param_value_size) {
     int start_pos = 0;
     int end_pos = 0;
     if (strlen(section) > 0) {
@@ -82,8 +88,19 @@ enum ConfigError parse_param_value(
     if (match > 0 || (end_pos >= 0 && end_pos - start_pos < m[1].rm_so))
         return CONFIG_PARAM_NOT_FOUND;
 
-    int res = sprintf(param_value, "%.*s", (int)(m[1].rm_eo - m[1].rm_so),
-        ini->str + start_pos + m[1].rm_so);
+    int len = (int)(m[1].rm_eo - m[1].rm_so);
+    int res;
+    if (param_value_size != (size_t)-1) {
+        if ((size_t)len >= param_value_size)
+            len = (int)param_value_size - 1;
+        res = snprintf(param_value, param_value_size, "%.*s", len,
+            ini->str + start_pos + m[1].rm_so);
+        if (res >= (int)param_value_size)
+            res = (int)param_value_size - 1;
+    } else {
+        res = sprintf(param_value, "%.*s", len,
+            ini->str + start_pos + m[1].rm_so);
+    }
     param_value[res] = 0;
 
     if (res >= 2 && param_value[0] == '"' && param_value[res - 1] == '"') {

--- a/src/hal/config.h
+++ b/src/hal/config.h
@@ -41,6 +41,12 @@ bool open_config(struct IniConfig *ini, FILE **file);
 enum ConfigError find_sections(struct IniConfig *ini);
 enum ConfigError section_pos(
     struct IniConfig *ini, const char *section, int *start_pos, int *end_pos);
+/* Bounded form of parse_param_value(): the unbounded one sprintf()s the matched
+ * value straight into the caller's buffer, which overflows small fields. */
+enum ConfigError parse_param_value_n(
+    struct IniConfig *ini, const char *section, const char *param_name,
+    char *param_value, size_t param_value_size);
+
 enum ConfigError parse_param_value(
     struct IniConfig *ini, const char *section, const char *param_name,
     char *param_value);

--- a/src/hal/tools.c
+++ b/src/hal/tools.c
@@ -140,6 +140,28 @@ int compile_regex(regex_t *r, const char *regex_text) {
 }
 
 
+int escape_json(char *dst, const char *src, size_t maxlen)
+{
+    size_t o = 0;
+
+    for (; src && *src && o + 7 < maxlen; src++) {
+        unsigned char c = (unsigned char)*src;
+
+        if (c == '"' || c == '\\') {
+            dst[o++] = '\\';
+            dst[o++] = c;
+        } else if (c < 0x20) {
+            o += snprintf(dst + o, maxlen - o, "\\u%04x", c);
+        } else {
+            dst[o++] = c;
+        }
+    }
+
+    dst[o] = 0;
+    return o;
+}
+
+
 int escape_url(char *dst, const char *src, size_t maxlen) {
     static const char hex[] = "0123456789ABCDEF";
     int len = 0;
@@ -516,4 +538,20 @@ void uuid_generate(char *uuid) {
         }
     }
     uuid[36] = '\0';
+}
+
+int parse_ranged(const char *value, long min, long max, long *out)
+{
+    char *remain;
+    long result;
+
+    errno = 0;
+    result = strtol(value, &remain, 10);
+
+    if (remain == value || (remain && *remain) || errno == ERANGE ||
+        result < min || result > max)
+        return 0;
+
+    *out = result;
+    return 1;
 }

--- a/src/hal/tools.h
+++ b/src/hal/tools.h
@@ -47,6 +47,8 @@ int color_parse(const char *str);
 
 int compile_regex(regex_t *r, const char *regex_text);
 
+int escape_json(char *dst, const char *src, size_t maxlen);
+
 int escape_url(char *dst, const char *src, size_t maxlen);
 
 void generate_nonce(char *nonce, size_t len);
@@ -72,6 +74,8 @@ char ip_in_cidr(const char *ip, const char *cidr);
 char *memstr(char *haystack, char *needle, int size, char needlesize);
 
 unsigned int millis();
+
+int parse_ranged(const char *value, long min, long max, long *out);
 
 void reverse(void *arr, size_t width);
 

--- a/src/main.c
+++ b/src/main.c
@@ -73,6 +73,7 @@ int main(int argc, char *argv[]) {
 
     if (app_config.rtsp_enable) {
         rtspHandle = rtsp_create(RTSP_MAXIMUM_CONNECTIONS, app_config.rtsp_port, 1);
+        rtsp_latch_audio_codec();
         HAL_INFO("rtsp", "Started listening for clients...\n");
         if (app_config.rtsp_enable_auth) {
             if (EMPTY(app_config.rtsp_auth_user) || EMPTY(app_config.rtsp_auth_pass))

--- a/src/media.c
+++ b/src/media.c
@@ -39,6 +39,67 @@ int save_audio_stream(hal_audframe *frame) {
     return EXIT_SUCCESS;
 }
 
+static unsigned char pcm_to_alaw(short pcm)
+{
+    int sign = (pcm & 0x8000) >> 8, s = sign ? -pcm - 1 : pcm, exp = 7;
+    if (s > 32635) s = 32635;
+    if (s >= 256) {
+        for (int m = 0x4000; !(s & m) && exp > 0; m >>= 1) exp--;
+        s = ((exp << 4) | ((s >> (exp + 3)) & 0x0f));
+    } else
+        s >>= 4;
+    return (unsigned char)((s ^ (sign ? 0xd5 : 0x55)));
+}
+
+/* RTSP G.711: resample the capture rate to 8 kHz (block average) and A-law
+ * encode, sending one RTP packet per 20 ms; MP3 keeps feeding the MP4/HTTP/RTMP
+ * outputs.
+ *
+ * The ratio is carried in 16.16 fixed point rather than as an integer divisor:
+ * srate is accepted anywhere in 8000..96000, and truncating 44100 / 8000 to 5
+ * emitted 8820 samples a second against an SDP and RTP clock of 8000, so the
+ * stream ran fast and the 160-byte packets were 18.1 ms rather than 20. */
+static void rtsp_pcma_feed(short *pcm, unsigned int samples)
+{
+    static unsigned char alaw[160];
+    static unsigned int fill, phase, step;
+    static int acc, accN;
+    if (!step) {
+        unsigned int srate = app_config.audio_srate > 0 ? app_config.audio_srate : 8000;
+        step = (srate << 16) / 8000;
+        if (!step) step = 1 << 16;
+    }
+    for (unsigned int i = 0; i < samples; i++) {
+        acc += pcm[i];
+        accN++;
+        phase += 1 << 16;
+        if (phase < step) continue;
+        phase -= step;
+        alaw[fill++] = pcm_to_alaw((short)(acc / accN));
+        acc = 0; accN = 0;
+        if (fill == sizeof(alaw)) {
+            rtp_send_pcma(rtspHandle, alaw, sizeof(alaw));
+            fill = 0;
+        }
+    }
+}
+
+/* The codec RTSP sessions were negotiated with.
+ *
+ * app_config.rtsp_audio_codec can be changed at runtime through /api/rtsp, but
+ * switching the payload type and clock under a live session would leave every
+ * client decoding the wrong thing without a new DESCRIBE/SETUP. The value the
+ * media path uses is therefore latched when the server starts, which is what
+ * the API means when it says the change applies after a restart. */
+static char rtspCodec[sizeof(app_config.rtsp_audio_codec)];
+
+void rtsp_latch_audio_codec(void) {
+    strncpy(rtspCodec, app_config.rtsp_audio_codec, sizeof(rtspCodec) - 1);
+    rtspCodec[sizeof(rtspCodec) - 1] = 0;
+}
+
+static char rtsp_pcma_active(void) { return EQUALS(rtspCodec, "pcma"); }
+
 void *aenc_thread(void) {
     static uint8_t frame_buf[AUD_FRAME_MAX + 2];
     const uint32_t mp3FrmSize =
@@ -56,7 +117,7 @@ void *aenc_thread(void) {
             pthread_mutex_lock(&mp4Mtx);
             mp4_ingest_audio(mp3Buf.buf, mp3FrmSize);
             pthread_mutex_unlock(&mp4Mtx);
-            if (app_config.rtsp_enable)
+            if (app_config.rtsp_enable && !rtsp_pcma_active())
                 rtp_send_mp3(rtspHandle, mp3Buf.buf, mp3FrmSize);
             rtmp_ingest_audio(mp3Buf.buf, mp3FrmSize);
             mp3Buf.offset -= mp3FrmSize;
@@ -83,6 +144,18 @@ void *aenc_thread(void) {
         outFrame.seq = seq++;
         outFrame.timestamp = millis();
         send_pcm_to_client(&outFrame);
+        if (app_config.rtsp_enable && rtsp_pcma_active())
+            rtsp_pcma_feed((short *)(frame_buf + 2), flen / 2);
+
+        /* The software MP3 encoder is the single most expensive thing on a
+         * small SoC (24% of an ARM1176 at 48 kHz); skip it while nothing
+         * consumes MP3: no HTTP MP3/MP4 client, no recording, no RTMP, and
+         * RTSP carrying G.711 */
+        if (!recordOn && !app_config.stream_enable && !http_audio_clients() &&
+            !(app_config.rtsp_enable && !rtsp_pcma_active())) {
+            pcmPos = 0;
+            continue;
+        }
 
         unsigned int pcmLen = flen / 2;
         short *pcmPack = (short *)(frame_buf + 2);

--- a/src/media.c
+++ b/src/media.c
@@ -51,19 +51,29 @@ static unsigned char pcm_to_alaw(short pcm)
     return (unsigned char)((s ^ (sign ? 0xd5 : 0x55)));
 }
 
-/* RTSP G.711: resample the capture rate to 8 kHz (block average) and A-law
- * encode, sending one RTP packet per 20 ms; MP3 keeps feeding the MP4/HTTP/RTMP
- * outputs.
- *
- * The ratio is carried in 16.16 fixed point rather than as an integer divisor:
- * srate is accepted anywhere in 8000..96000, and truncating 44100 / 8000 to 5
- * emitted 8820 samples a second against an SDP and RTP clock of 8000, so the
- * stream ran fast and the 160-byte packets were 18.1 ms rather than 20. */
+/* mu-law (G.711 U, PT 0): 4085-step non-uniform compressor. Mirrors the A-law
+ * routine so both stay branch-light for soft-float ARM. */
+static unsigned char pcm_to_ulaw(short pcm)
+{
+    int sign = (pcm >> 8) & 0x80, s = sign ? -pcm : pcm, exp = 7;
+    if (s > 32635) s = 32635;
+    s += 0x84;                         /* bias: mu-law does not encode zero alone */
+    if (s > 0x7FFF) s = 0x7FFF;
+    for (int m = 0x4000; !(s & m) && exp > 0; m >>= 1) exp--;
+    return (unsigned char)~(sign | (exp << 4) | ((s >> (exp + 3)) & 0x0f));
+}
+
+static char rtsp_codec[sizeof(app_config.rtsp_audio_codec)];
+
+/* Any G.711 codec: the 8 kHz sample drop + encode path, versus MP3 */
+static char rtsp_g711_active(void) { return EQUALS(rtsp_codec, "pcma") || EQUALS(rtsp_codec, "pcmu"); }
+
 static void rtsp_pcma_feed(short *pcm, unsigned int samples)
 {
     static unsigned char alaw[160];
     static unsigned int fill, phase, step;
-    static int acc, accN;
+    static int acc, acc_n;
+    char ulaw = EQUALS(rtsp_codec, "pcmu");
     if (!step) {
         unsigned int srate = app_config.audio_srate > 0 ? app_config.audio_srate : 8000;
         step = (srate << 16) / 8000;
@@ -71,34 +81,26 @@ static void rtsp_pcma_feed(short *pcm, unsigned int samples)
     }
     for (unsigned int i = 0; i < samples; i++) {
         acc += pcm[i];
-        accN++;
+        acc_n++;
         phase += 1 << 16;
         if (phase < step) continue;
         phase -= step;
-        alaw[fill++] = pcm_to_alaw((short)(acc / accN));
-        acc = 0; accN = 0;
+        alaw[fill++] = ulaw ? pcm_to_ulaw((short)(acc / acc_n)) : pcm_to_alaw((short)(acc / acc_n));
+        acc = 0; acc_n = 0;
         if (fill == sizeof(alaw)) {
-            rtp_send_pcma(rtspHandle, alaw, sizeof(alaw));
+            if (ulaw)
+                rtp_send_pcmu(rtspHandle, alaw, sizeof(alaw));
+            else
+                rtp_send_pcma(rtspHandle, alaw, sizeof(alaw));
             fill = 0;
         }
     }
 }
 
-/* The codec RTSP sessions were negotiated with.
- *
- * app_config.rtsp_audio_codec can be changed at runtime through /api/rtsp, but
- * switching the payload type and clock under a live session would leave every
- * client decoding the wrong thing without a new DESCRIBE/SETUP. The value the
- * media path uses is therefore latched when the server starts, which is what
- * the API means when it says the change applies after a restart. */
-static char rtspCodec[sizeof(app_config.rtsp_audio_codec)];
-
 void rtsp_latch_audio_codec(void) {
-    strncpy(rtspCodec, app_config.rtsp_audio_codec, sizeof(rtspCodec) - 1);
-    rtspCodec[sizeof(rtspCodec) - 1] = 0;
+    strncpy(rtsp_codec, app_config.rtsp_audio_codec, sizeof(rtsp_codec) - 1);
+    rtsp_codec[sizeof(rtsp_codec) - 1] = 0;
 }
-
-static char rtsp_pcma_active(void) { return EQUALS(rtspCodec, "pcma"); }
 
 void *aenc_thread(void) {
     static uint8_t frame_buf[AUD_FRAME_MAX + 2];
@@ -117,7 +119,7 @@ void *aenc_thread(void) {
             pthread_mutex_lock(&mp4Mtx);
             mp4_ingest_audio(mp3Buf.buf, mp3FrmSize);
             pthread_mutex_unlock(&mp4Mtx);
-            if (app_config.rtsp_enable && !rtsp_pcma_active())
+            if (app_config.rtsp_enable && !rtsp_g711_active())
                 rtp_send_mp3(rtspHandle, mp3Buf.buf, mp3FrmSize);
             rtmp_ingest_audio(mp3Buf.buf, mp3FrmSize);
             mp3Buf.offset -= mp3FrmSize;
@@ -144,15 +146,11 @@ void *aenc_thread(void) {
         outFrame.seq = seq++;
         outFrame.timestamp = millis();
         send_pcm_to_client(&outFrame);
-        if (app_config.rtsp_enable && rtsp_pcma_active())
+        if (app_config.rtsp_enable && rtsp_g711_active())
             rtsp_pcma_feed((short *)(frame_buf + 2), flen / 2);
 
-        /* The software MP3 encoder is the single most expensive thing on a
-         * small SoC (24% of an ARM1176 at 48 kHz); skip it while nothing
-         * consumes MP3: no HTTP MP3/MP4 client, no recording, no RTMP, and
-         * RTSP carrying G.711 */
-        if (!recordOn && !app_config.stream_enable && !http_audio_clients() &&
-            !(app_config.rtsp_enable && !rtsp_pcma_active())) {
+        if (!recordOn && !app_config.stream_enable && !any_http_audio() &&
+            !(app_config.rtsp_enable && !rtsp_g711_active())) {
             pcmPos = 0;
             continue;
         }

--- a/src/media.h
+++ b/src/media.h
@@ -47,3 +47,5 @@ int media_mjpeg_disable(void);
 int media_mjpeg_enable(void);
 int media_mp4_disable(void);
 int media_mp4_enable(void);
+
+void rtsp_latch_audio_codec(void);

--- a/src/rtsp/rtp.c
+++ b/src/rtsp/rtp.c
@@ -5,6 +5,7 @@
 #include <netdb.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 
 #include "rtsp_server.h"
 #include "common.h"
@@ -34,6 +35,46 @@ struct __transfer_set_t {
     rtsp_handle h;
     int track_id;
 };
+
+/* 90 kHz video / 8 kHz G.711 timestamps of the frame being sent */
+static unsigned int __frame_ts_video, __frame_ts_audio;
+
+/* Block until the socket can take more data (or 100 ms), instead of spinning */
+static inline void __wait_out(int fd)
+{
+    struct pollfd p = { .fd = fd, .events = POLLOUT };
+    poll(&p, 1, 100);
+}
+
+/* Write out the staged interleaved data; call with write_mutex held */
+static int __tcp_flush(struct connection_item_t *con)
+{
+    unsigned int sent = 0;
+    while (sent < con->tx_len) {
+        int r = send(con->client_fd, con->tx_buf + sent, con->tx_len - sent, 0);
+        if (r > 0) sent += r;
+        else if (r < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) { __wait_out(con->client_fd); }
+        else { con->tx_len = 0; return FAILURE; }
+    }
+    con->tx_len = 0;
+    return SUCCESS;
+}
+
+static int __tcp_flush_each(struct list_t *e, void *v)
+{
+    struct transfer_item_t *trans;
+    struct connection_item_t *con;
+    list_upcast(trans, e);
+    MUST(con = trans->con, return FAILURE);
+    /* Packets are only ever staged from the interleaved branch below, so
+     * anything in tx_buf came from a TCP transfer whichever track sent it.
+     * Testing track 0 here never flushed a client that set up audio alone. */
+    if (!con->tx_buf || !con->tx_len) return SUCCESS;
+    pthread_mutex_lock(&con->write_mutex);
+    int ret = __tcp_flush(con);
+    pthread_mutex_unlock(&con->write_mutex);
+    return ret;
+}
 
 /******************************************************************************
  *              PRIVATE FUNCTIONS
@@ -152,6 +193,26 @@ static inline int __transfer_nal_mpga(struct list_head_t *trans_list, unsigned c
     return SUCCESS;
 }
 
+/* One RTP packet per chunk of G.711 A-law bytes (20 ms = 160 bytes at 8 kHz) */
+static inline int __transfer_pcma(struct list_head_t *trans_list, unsigned char *ptr, size_t size)
+{
+    struct nal_rtp_t rtp;
+    rtp_hdr_t *p_header = &(rtp.packet.header);
+
+    p_header->version = 2;
+    p_header->p = 0;
+    p_header->x = 0;
+    p_header->cc = 0;
+    p_header->pt = 8;
+    p_header->m = 1;
+
+    memcpy(rtp.packet.payload, ptr, size);
+    rtp.rtpsize = size + sizeof(rtp_hdr_t);
+
+    ASSERT(__rtp_send(&rtp, trans_list) == SUCCESS, return FAILURE);
+    return SUCCESS;
+}
+
 static inline int __rtp_send_eachconnection(struct list_t *e, void *v)
 {
     int send_bytes;
@@ -166,8 +227,11 @@ static inline int __rtp_send_eachconnection(struct list_t *e, void *v)
     if (!con->trans[track_id].server_port_rtp && !con->trans[track_id].is_tcp) return SUCCESS;
 
     rtp->packet.header.seq = htons(con->trans[track_id].rtp_seq);
-    if (rtp->packet.header.m)
-        con->trans[track_id].rtp_timestamp = (millis() * 90) & UINT32_MAX;
+    /* One timestamp per frame, taken when the frame starts (see rtp_send_*):
+     * stamping only the marker packet gave every earlier packet of a frame
+     * the previous frame's time, so receivers saw timestamps run backwards
+     * inside a frame and players stalled and then raced to catch up */
+    con->trans[track_id].rtp_timestamp = track_id ? __frame_ts_audio : __frame_ts_video;
     rtp->packet.header.ts = htonl(con->trans[track_id].rtp_timestamp);
     rtp->packet.header.ssrc = htonl(con->ssrc);
     con->trans[track_id].rtp_seq += 1;
@@ -180,11 +244,30 @@ static inline int __rtp_send_eachconnection(struct list_t *e, void *v)
         head[3] = rtp->rtpsize & 0xFF;
 
         pthread_mutex_lock(&con->write_mutex);
+        if (con->tx_buf) {
+            /* stage the packet; one send() per frame or per RTSP_TX_BATCH */
+            int ok = 1;
+            if (con->tx_len + 4 + rtp->rtpsize > RTSP_TX_BATCH)
+                ok = __tcp_flush(con) == SUCCESS;
+            if (ok) {
+                memcpy(con->tx_buf + con->tx_len, head, 4);
+                memcpy(con->tx_buf + con->tx_len + 4, &(rtp->packet), rtp->rtpsize);
+                con->tx_len += 4 + rtp->rtpsize;
+            }
+            pthread_mutex_unlock(&con->write_mutex);
+            if (ok) {
+                con->trans[track_id].rtcp_packet_cnt += 1;
+                con->trans[track_id].rtcp_octet += rtp->rtpsize;
+                return SUCCESS;
+            }
+            ERR("send (staged):%s\n", strerror(errno));
+            return FAILURE;
+        }
         int sent_h = 0;
         while (sent_h < 4) {
             int r = send(con->client_fd, head + sent_h, 4 - sent_h, 0);
             if (r > 0) sent_h += r;
-            else if (r < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) usleep(1000);
+            else if (r < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) { __wait_out(con->client_fd); }
             else { sent_h = -1; break; }
         }
         if (sent_h == 4) {
@@ -192,7 +275,7 @@ static inline int __rtp_send_eachconnection(struct list_t *e, void *v)
             while (sent_b < rtp->rtpsize) {
                 int r = send(con->client_fd, (char*)&(rtp->packet) + sent_b, rtp->rtpsize - sent_b, 0);
                 if (r > 0) sent_b += r;
-                else if (r < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) usleep(1000);
+                else if (r < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) { __wait_out(con->client_fd); }
                 else { sent_b = -1; break; }
             }
             send_bytes = sent_b;
@@ -423,6 +506,12 @@ int rtp_send_h26x(rtsp_handle h, hal_vidstream *stream, char isH265)
     }
 
     h->isH265 = isH265;
+    /* Stamp with the encoder's capture time (pack timestamps are microseconds)
+     * so receivers pace frames correctly even when a large keyframe makes the
+     * sender deliver the following frames in a burst; fall back to the send
+     * time for HALs that leave the timestamp at zero */
+    __frame_ts_video = (stream->count && stream->pack[0].timestamp) ?
+        (unsigned int)(stream->pack[0].timestamp * 9 / 100) : ((millis() * 90) & UINT32_MAX);
 
     for (int i = 0; i < stream->count; i++) {
         ASSERT(__retrieve_sprop(h, stream->pack[i].data + stream->pack[i].offset, 
@@ -436,7 +525,7 @@ int rtp_send_h26x(rtsp_handle h, hal_vidstream *stream, char isH265)
     rtsp_lock(h);
     ASSERT(list_map_inline(&h->con_list, (__rtp_setup_transfer), &trans) == SUCCESS, ({rtsp_unlock(h); goto error;}));
     rtsp_unlock(h);
-    
+
     if (trans.list_head.list) {
         for (int i = 0; i < stream->count; i++) {
             unsigned char *data = stream->pack[i].data + stream->pack[i].offset;
@@ -451,6 +540,7 @@ int rtp_send_h26x(rtsp_handle h, hal_vidstream *stream, char isH265)
                 ASSERT(__transfer_nal_h26x(&(trans.list_head), data, length, h->isH265) == SUCCESS, goto error);
             }
         }
+        ASSERT(list_map_inline(&(trans.list_head), (__tcp_flush_each), NULL) == SUCCESS, goto error);
         ASSERT(list_map_inline(&(trans.list_head), (__rtcp_poll), &track_id) == SUCCESS, goto error);
     } 
 
@@ -462,8 +552,46 @@ error:
     return ret;
 }
 
+int rtp_send_pcma(rtsp_handle h, unsigned char *buf, size_t len)
+{
+    /* G.711 is one byte per sample, so the 8 kHz clock advances by exactly the
+     * number of samples in the packet. Deriving this from millis() instead let
+     * the stamps drift away from the audio actually sent. */
+    static unsigned int pcma_ts;
+    __frame_ts_audio = pcma_ts;
+    pcma_ts += (unsigned int)len;
+    int ret = FAILURE;
+    int track_id = 1;
+    struct __transfer_set_t trans = {};
+
+    DASSERT(h, return FAILURE);
+    if (gbl_get_quit(h->pool->sharedp->gbl))
+        return FAILURE;
+
+    h->audioPt = 8;
+
+    trans.h = h;
+    trans.track_id = track_id;
+
+    rtsp_lock(h);
+    ASSERT(list_map_inline(&h->con_list, (__rtp_setup_transfer), &trans) == SUCCESS, ({rtsp_unlock(h); goto error;}));
+    rtsp_unlock(h);
+
+    if (trans.list_head.list) {
+        ASSERT(__transfer_pcma(&(trans.list_head), buf, len) == SUCCESS, goto error);
+        ASSERT(list_map_inline(&(trans.list_head), (__tcp_flush_each), NULL) == SUCCESS, goto error);
+        ASSERT(list_map_inline(&(trans.list_head), (__rtcp_poll), &track_id) == SUCCESS, goto error);
+    }
+    ret = SUCCESS;
+
+error:
+    list_destroy(&(trans.list_head));
+    return ret;
+}
+
 int rtp_send_mp3(rtsp_handle h, unsigned char *buf, size_t len)
 {
+    __frame_ts_audio = (millis() * 90) & UINT32_MAX;   /* 90 kHz MPEG audio */
     int ret = FAILURE;
     int track_id = 1;
     struct __transfer_set_t trans = {};
@@ -490,6 +618,7 @@ int rtp_send_mp3(rtsp_handle h, unsigned char *buf, size_t len)
     
     if (trans.list_head.list) {
         ASSERT(__transfer_nal_mpga(&(trans.list_head), buf, len) == SUCCESS, goto error);
+        ASSERT(list_map_inline(&(trans.list_head), (__tcp_flush_each), NULL) == SUCCESS, goto error);
         ASSERT(list_map_inline(&(trans.list_head), (__rtcp_poll), &track_id) == SUCCESS, goto error);
     } 
 

--- a/src/rtsp/rtp.c
+++ b/src/rtsp/rtp.c
@@ -36,17 +36,14 @@ struct __transfer_set_t {
     int track_id;
 };
 
-/* 90 kHz video / 8 kHz G.711 timestamps of the frame being sent */
 static unsigned int __frame_ts_video, __frame_ts_audio;
 
-/* Block until the socket can take more data (or 100 ms), instead of spinning */
 static inline void __wait_out(int fd)
 {
     struct pollfd p = { .fd = fd, .events = POLLOUT };
     poll(&p, 1, 100);
 }
 
-/* Write out the staged interleaved data; call with write_mutex held */
 static int __tcp_flush(struct connection_item_t *con)
 {
     unsigned int sent = 0;
@@ -193,8 +190,8 @@ static inline int __transfer_nal_mpga(struct list_head_t *trans_list, unsigned c
     return SUCCESS;
 }
 
-/* One RTP packet per chunk of G.711 A-law bytes (20 ms = 160 bytes at 8 kHz) */
-static inline int __transfer_pcma(struct list_head_t *trans_list, unsigned char *ptr, size_t size)
+/* One RTP packet per 20 ms of 8 kHz G.711 (PT 8 for A-law, 0 for mu-law) */
+static inline int __transfer_g711(struct list_head_t *trans_list, unsigned char *ptr, size_t size, unsigned char pt)
 {
     struct nal_rtp_t rtp;
     rtp_hdr_t *p_header = &(rtp.packet.header);
@@ -203,7 +200,7 @@ static inline int __transfer_pcma(struct list_head_t *trans_list, unsigned char 
     p_header->p = 0;
     p_header->x = 0;
     p_header->cc = 0;
-    p_header->pt = 8;
+    p_header->pt = pt;
     p_header->m = 1;
 
     memcpy(rtp.packet.payload, ptr, size);
@@ -227,10 +224,6 @@ static inline int __rtp_send_eachconnection(struct list_t *e, void *v)
     if (!con->trans[track_id].server_port_rtp && !con->trans[track_id].is_tcp) return SUCCESS;
 
     rtp->packet.header.seq = htons(con->trans[track_id].rtp_seq);
-    /* One timestamp per frame, taken when the frame starts (see rtp_send_*):
-     * stamping only the marker packet gave every earlier packet of a frame
-     * the previous frame's time, so receivers saw timestamps run backwards
-     * inside a frame and players stalled and then raced to catch up */
     con->trans[track_id].rtp_timestamp = track_id ? __frame_ts_audio : __frame_ts_video;
     rtp->packet.header.ts = htonl(con->trans[track_id].rtp_timestamp);
     rtp->packet.header.ssrc = htonl(con->ssrc);
@@ -245,7 +238,6 @@ static inline int __rtp_send_eachconnection(struct list_t *e, void *v)
 
         pthread_mutex_lock(&con->write_mutex);
         if (con->tx_buf) {
-            /* stage the packet; one send() per frame or per RTSP_TX_BATCH */
             int ok = 1;
             if (con->tx_len + 4 + rtp->rtpsize > RTSP_TX_BATCH)
                 ok = __tcp_flush(con) == SUCCESS;
@@ -552,14 +544,14 @@ error:
     return ret;
 }
 
-int rtp_send_pcma(rtsp_handle h, unsigned char *buf, size_t len)
+static int __rtp_send_g711(rtsp_handle h, unsigned char *buf, size_t len, unsigned char pt)
 {
     /* G.711 is one byte per sample, so the 8 kHz clock advances by exactly the
      * number of samples in the packet. Deriving this from millis() instead let
      * the stamps drift away from the audio actually sent. */
-    static unsigned int pcma_ts;
-    __frame_ts_audio = pcma_ts;
-    pcma_ts += (unsigned int)len;
+    static unsigned int g711_ts;
+    __frame_ts_audio = g711_ts;
+    g711_ts += (unsigned int)len;
     int ret = FAILURE;
     int track_id = 1;
     struct __transfer_set_t trans = {};
@@ -568,7 +560,7 @@ int rtp_send_pcma(rtsp_handle h, unsigned char *buf, size_t len)
     if (gbl_get_quit(h->pool->sharedp->gbl))
         return FAILURE;
 
-    h->audioPt = 8;
+    h->audioPt = pt;
 
     trans.h = h;
     trans.track_id = track_id;
@@ -578,7 +570,7 @@ int rtp_send_pcma(rtsp_handle h, unsigned char *buf, size_t len)
     rtsp_unlock(h);
 
     if (trans.list_head.list) {
-        ASSERT(__transfer_pcma(&(trans.list_head), buf, len) == SUCCESS, goto error);
+        ASSERT(__transfer_g711(&(trans.list_head), buf, len, pt) == SUCCESS, goto error);
         ASSERT(list_map_inline(&(trans.list_head), (__tcp_flush_each), NULL) == SUCCESS, goto error);
         ASSERT(list_map_inline(&(trans.list_head), (__rtcp_poll), &track_id) == SUCCESS, goto error);
     }
@@ -587,6 +579,16 @@ int rtp_send_pcma(rtsp_handle h, unsigned char *buf, size_t len)
 error:
     list_destroy(&(trans.list_head));
     return ret;
+}
+
+int rtp_send_pcma(rtsp_handle h, unsigned char *buf, size_t len)
+{
+    return __rtp_send_g711(h, buf, len, 8);
+}
+
+int rtp_send_pcmu(rtsp_handle h, unsigned char *buf, size_t len)
+{
+    return __rtp_send_g711(h, buf, len, 0);
 }
 
 int rtp_send_mp3(rtsp_handle h, unsigned char *buf, size_t len)

--- a/src/rtsp/rtsp.c
+++ b/src/rtsp/rtsp.c
@@ -191,8 +191,8 @@ static void __method_describe(struct connection_item_t *p, rtsp_handle h)
             "\r\n"
             "m=audio 0 RTP/AVP %d\r\n"
             "a=control:track=1\r\n"
-            "a=rtpmap:%d %s/90000\r\n",
-            h->audioPt, h->audioPt, audioRtpfmt);
+            "a=rtpmap:%d %s/%d\r\n",
+            h->audioPt, h->audioPt, audioRtpfmt, (h->audioPt == 8 || h->audioPt == 0) ? 8000 : 90000);
     }
 
     if (h->isH265 &&
@@ -563,6 +563,8 @@ __connection_list_add(bufpool_handle con_pool, struct list_head_t *head, int fd,
     ASSERT((p->fp_tcp_read = fdopen(fd, "r")), goto error);
     ASSERT((p->fp_tcp_write = fdopen(fd, "w")), goto error);
 
+    p->tx_len = 0;
+    if (!p->tx_buf) p->tx_buf = malloc(RTSP_TX_BATCH);
     p->con_state = __CON_S_INIT;
 
     return list_add(head, &(p->list_entry));
@@ -655,6 +657,11 @@ static inline int __bind_rtp(struct connection_item_t *con )
 
     tmp = 1;
     setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &tmp, sizeof(tmp));
+    {
+        int sz = 512 * 1024;   /* absorb a whole keyframe, see the TCP accept path */
+        if (setsockopt(server_fd, SOL_SOCKET, SO_SNDBUFFORCE, &sz, sizeof(sz)))
+            setsockopt(server_fd, SOL_SOCKET, SO_SNDBUF, &sz, sizeof(sz));
+    }
 
     ASSERT(bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0, ({
                 ERR("bind:%s\n", strerror(errno));
@@ -747,6 +754,17 @@ static inline int __accept_proc_sock(rtsp_handle h, int server_fd, struct sock_s
 
         /* set server fd to non-blocking */
         fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK);
+
+        /* A keyframe is a few hundred KB and the kernel's default TCP send
+         * buffer (64 KB on small boards) cannot hold it: the interleaved sender
+         * then spins on partial writes for as long as the link takes to drain,
+         * hundreds of ms of CPU per keyframe. Ask for a buffer that fits one
+         * (SO_SNDBUFFORCE bypasses wmem_max, which needs root). */
+        {
+            int sz = 512 * 1024;
+            if (setsockopt(fd, SOL_SOCKET, SO_SNDBUFFORCE, &sz, sizeof(sz)))
+                setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sz, sizeof(sz));
+        }
 
         /* update connection-list exclusively */
         ASSERT(__connection_list_add(h->con_pool, &h->con_list, fd, from_addr) == SUCCESS,

--- a/src/rtsp/rtsp.h
+++ b/src/rtsp/rtsp.h
@@ -113,8 +113,13 @@ struct connection_item_t {
     unsigned long long given_session_id;
     unsigned int ssrc;
     pthread_mutex_t write_mutex;
+    /* Interleaved (TCP) output is staged here and written with one send()
+     * per frame: on small SoCs a send() costs ~100 us whatever its size */
+    unsigned char *tx_buf;
+    unsigned int tx_len;
     struct list_t list_entry;
 };
+#define RTSP_TX_BATCH (64 * 1024)
 
 struct transfer_item_t {
     struct list_t list_entry;

--- a/src/rtsp/rtsp_server.h
+++ b/src/rtsp/rtsp_server.h
@@ -32,6 +32,7 @@ typedef struct __rtsp_obj_t *rtsp_handle;
 void rtp_disable_audio(rtsp_handle h);
 int rtp_send_h26x(rtsp_handle h, hal_vidstream *stream, char isH265);
 int rtp_send_mp3(rtsp_handle h, unsigned char *buf, size_t len);
+int rtp_send_pcma(rtsp_handle h, unsigned char *buf, size_t len);
 
 extern void rtsp_finish(rtsp_handle h);
 

--- a/src/rtsp/rtsp_server.h
+++ b/src/rtsp/rtsp_server.h
@@ -33,6 +33,7 @@ void rtp_disable_audio(rtsp_handle h);
 int rtp_send_h26x(rtsp_handle h, hal_vidstream *stream, char isH265);
 int rtp_send_mp3(rtsp_handle h, unsigned char *buf, size_t len);
 int rtp_send_pcma(rtsp_handle h, unsigned char *buf, size_t len);
+int rtp_send_pcmu(rtsp_handle h, unsigned char *buf, size_t len);
 
 extern void rtsp_finish(rtsp_handle h);
 

--- a/src/server.c
+++ b/src/server.c
@@ -218,7 +218,41 @@ void send_h26x_to_client(char index, hal_vidstream *stream) {
     }
 }
 
+/* Escape a string for use inside a JSON string literal. Usernames and codec
+ * names come from a request or the config file, and an unescaped quote or
+ * backslash makes the response unparseable for the web UI's JSON.parse(). */
+static const char *json_str(char *dst, size_t dstsz, const char *src) {
+    size_t o = 0;
+    for (; src && *src && o + 7 < dstsz; src++) {
+        unsigned char c = (unsigned char)*src;
+        if (c == '"' || c == '\\') { dst[o++] = '\\'; dst[o++] = c; }
+        else if (c < 0x20) o += snprintf(dst + o, dstsz - o, "\\u%04x", c);
+        else dst[o++] = c;
+    }
+    dst[o] = 0;
+    return dst;
+}
+
+/* Whether any HTTP client is consuming the MP3 encoder's output (raw MP3 or MP4) */
+char http_audio_clients(void) {
+    char any = 0;
+    pthread_mutex_lock(&client_fds_mutex);
+    for (unsigned int i = 0; i < HTTP_MAX_CLIENTS; ++i)
+        if (client_fds[i].sockFd >= 0 &&
+            (client_fds[i].type == STREAM_MP4 || client_fds[i].type == STREAM_MP3)) { any = 1; break; }
+    pthread_mutex_unlock(&client_fds_mutex);
+    return any;
+}
+
 void send_mp4_to_client(char index, hal_vidstream *stream, char isH265) {
+    /* Building moof/mdat for every frame is wasted work without a consumer;
+     * the parameter sets are still cached so a header is ready when one connects */
+    char anyClient = 0;
+    pthread_mutex_lock(&client_fds_mutex);
+    for (unsigned int i = 0; i < HTTP_MAX_CLIENTS; ++i)
+        if (client_fds[i].sockFd >= 0 && client_fds[i].type == STREAM_MP4) { anyClient = 1; break; }
+    pthread_mutex_unlock(&client_fds_mutex);
+
     for (unsigned int i = 0; i < stream->count; ++i) {
         hal_vidpack *pack = &stream->pack[i];
         unsigned char *pack_data = pack->data + pack->offset;
@@ -235,11 +269,14 @@ void send_mp4_to_client(char index, hal_vidstream *stream, char isH265) {
                 mp4_set_pps(pack_data + pack->nalu[j].offset + scLen, pack->nalu[j].length - scLen, isH265);
             else if (pack->nalu[j].type == NalUnitType_VPS_HEVC && pack->nalu[j].length <= UINT16_MAX)
                 mp4_set_vps(pack_data + pack->nalu[j].offset + scLen, pack->nalu[j].length - scLen);
+            else if (!anyClient)
+                continue;
             else if (pack->nalu[j].type == NalUnitType_CodedSliceIdr || pack->nalu[j].type == NalUnitType_CodedSliceAux)
                 mp4_set_slice(pack_data + pack->nalu[j].offset + scLen, pack->nalu[j].length - scLen, 1);
             else if (pack->nalu[j].type == NalUnitType_CodedSliceNonIdr)
                 mp4_set_slice(pack_data + pack->nalu[j].offset + scLen, pack->nalu[j].length - scLen, 0);
         }
+        if (!anyClient) continue;
 
         static enum BufError err;
         char len_buf[50];
@@ -1177,6 +1214,83 @@ void respond_request(http_request_t *req) {
         return;
     }
 
+    if (EQUALS(req->uri, "/api/rtsp")) {
+        if (req->query) {
+            char *remain;
+            while (req->query) {
+                char *value = split(&req->query, "&");
+                if (!value || !*value) continue;
+                unescape_uri(value);
+                char *key = split(&value, "=");
+                if (!key || !*key || !value || !*value) continue;
+                if (EQUALS(key, "enable"))
+                    app_config.rtsp_enable = EQUALS_CASE(value, "true") || EQUALS(value, "1");
+                else if (EQUALS(key, "enable_auth"))
+                    app_config.rtsp_enable_auth = EQUALS_CASE(value, "true") || EQUALS(value, "1");
+                else if (EQUALS(key, "port")) {
+                    int result = strtol(value, &remain, 10);
+                    if (remain != value && result > 0 && result < 65536)
+                        app_config.rtsp_port = result;
+                } else if (EQUALS(key, "auth_user"))
+                    strncpy(app_config.rtsp_auth_user, value, sizeof(app_config.rtsp_auth_user) - 1);
+                else if (EQUALS(key, "auth_pass"))
+                    strncpy(app_config.rtsp_auth_pass, value, sizeof(app_config.rtsp_auth_pass) - 1);
+                else if (EQUALS(key, "audio_codec")) {
+                    /* only the codecs the RTP path implements */
+                    if (EQUALS(value, "pcma") || EQUALS(value, "mp3")) {
+                        strncpy(app_config.rtsp_audio_codec, value,
+                            sizeof(app_config.rtsp_audio_codec) - 1);
+                        app_config.rtsp_audio_codec[sizeof(app_config.rtsp_audio_codec) - 1] = 0;
+                    }
+                }
+            }
+        }
+        char escUser[sizeof(app_config.rtsp_auth_user) * 6 + 1];
+        char escCodec[sizeof(app_config.rtsp_audio_codec) * 6 + 1];
+        respLen = sprintf(response,
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: application/json;charset=UTF-8\r\n"
+            "Connection: close\r\n"
+            "\r\n"
+            "{\"enable\":%s,\"enable_auth\":%s,\"port\":%d,\"auth_user\":\"%s\",\"audio_codec\":\"%s\","
+            "\"note\":\"port and codec changes apply after restart\"}",
+            app_config.rtsp_enable ? "true" : "false", app_config.rtsp_enable_auth ? "true" : "false",
+            app_config.rtsp_port,
+            json_str(escUser, sizeof(escUser), app_config.rtsp_auth_user),
+            json_str(escCodec, sizeof(escCodec), app_config.rtsp_audio_codec));
+        send_and_close(req->clntFd, response, respLen);
+        return;
+    }
+    if (EQUALS(req->uri, "/api/onvif")) {
+        if (req->query) {
+            while (req->query) {
+                char *value = split(&req->query, "&");
+                if (!value || !*value) continue;
+                unescape_uri(value);
+                char *key = split(&value, "=");
+                if (!key || !*key || !value || !*value) continue;
+                if (EQUALS(key, "enable"))
+                    app_config.onvif_enable = EQUALS_CASE(value, "true") || EQUALS(value, "1");
+                else if (EQUALS(key, "enable_auth"))
+                    app_config.onvif_enable_auth = EQUALS_CASE(value, "true") || EQUALS(value, "1");
+                else if (EQUALS(key, "auth_user"))
+                    strncpy(app_config.onvif_auth_user, value, sizeof(app_config.onvif_auth_user) - 1);
+                else if (EQUALS(key, "auth_pass"))
+                    strncpy(app_config.onvif_auth_pass, value, sizeof(app_config.onvif_auth_pass) - 1);
+            }
+        }
+        char escOnvifUser[sizeof(app_config.onvif_auth_user) * 6 + 1];
+        respLen = sprintf(response,
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: application/json;charset=UTF-8\r\n"
+            "Connection: close\r\n"
+            "\r\n"
+            "{\"enable\":%s,\"enable_auth\":%s,\"auth_user\":\"%s\",\"note\":\"applies after restart\"}",
+            app_config.onvif_enable ? "true" : "false", app_config.onvif_enable_auth ? "true" : "false",
+            json_str(escOnvifUser, sizeof(escOnvifUser), app_config.onvif_auth_user));
+        send_and_close(req->clntFd, response, respLen);
+        return;
+    }
     if (EQUALS(req->uri, "/api/night")) {
         if (req->query) {
             char *remain;
@@ -1637,6 +1751,12 @@ void *server_thread(void *vargp) {
                         parse_request(req);
                         if (req->clntFd != -1) {
                             fcntl(req->clntFd, F_SETFL, fcntl(req->clntFd, F_GETFL, 0) & ~O_NONBLOCK);
+                            {
+                                /* A client that stops reading a stream (e.g. a browser that gave
+                                 * up on the MP4) must not block the whole server on send() */
+                                struct timeval tv = { .tv_sec = 5, .tv_usec = 0 };
+                                setsockopt(req->clntFd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+                            }
                             respond_request(req);
                         }
                         fds[i + 1].fd = -1;

--- a/src/server.c
+++ b/src/server.c
@@ -10,12 +10,12 @@ IMPORT_STR(.rodata, "../res/onvif/badauth.xml", badauthxml);
 extern const char badauthxml[];
 
 enum StreamType {
-    STREAM_H26X,
-    STREAM_JPEG,
-    STREAM_MJPEG,
-    STREAM_MP3,
-    STREAM_MP4,
-    STREAM_PCM
+    STREAM_H26X  = (1 << 0),
+    STREAM_JPEG  = (1 << 1),
+    STREAM_MJPEG = (1 << 2),
+    STREAM_MP3   = (1 << 3),
+    STREAM_MP4   = (1 << 4),
+    STREAM_PCM   = (1 << 5)
 };
 
 typedef struct {
@@ -218,35 +218,17 @@ void send_h26x_to_client(char index, hal_vidstream *stream) {
     }
 }
 
-/* Escape a string for use inside a JSON string literal. Usernames and codec
- * names come from a request or the config file, and an unescaped quote or
- * backslash makes the response unparseable for the web UI's JSON.parse(). */
-static const char *json_str(char *dst, size_t dstsz, const char *src) {
-    size_t o = 0;
-    for (; src && *src && o + 7 < dstsz; src++) {
-        unsigned char c = (unsigned char)*src;
-        if (c == '"' || c == '\\') { dst[o++] = '\\'; dst[o++] = c; }
-        else if (c < 0x20) o += snprintf(dst + o, dstsz - o, "\\u%04x", c);
-        else dst[o++] = c;
-    }
-    dst[o] = 0;
-    return dst;
-}
-
-/* Whether any HTTP client is consuming the MP3 encoder's output (raw MP3 or MP4) */
-char http_audio_clients(void) {
+char any_http_audio(void) {
     char any = 0;
     pthread_mutex_lock(&client_fds_mutex);
     for (unsigned int i = 0; i < HTTP_MAX_CLIENTS; ++i)
         if (client_fds[i].sockFd >= 0 &&
-            (client_fds[i].type == STREAM_MP4 || client_fds[i].type == STREAM_MP3)) { any = 1; break; }
+            (client_fds[i].type & (STREAM_MP3 | STREAM_MP4 | STREAM_PCM))) { any = 1; break; }
     pthread_mutex_unlock(&client_fds_mutex);
     return any;
 }
 
 void send_mp4_to_client(char index, hal_vidstream *stream, char isH265) {
-    /* Building moof/mdat for every frame is wasted work without a consumer;
-     * the parameter sets are still cached so a header is ready when one connects */
     char anyClient = 0;
     pthread_mutex_lock(&client_fds_mutex);
     for (unsigned int i = 0; i < HTTP_MAX_CLIENTS; ++i)
@@ -1228,16 +1210,15 @@ void respond_request(http_request_t *req) {
                 else if (EQUALS(key, "enable_auth"))
                     app_config.rtsp_enable_auth = EQUALS_CASE(value, "true") || EQUALS(value, "1");
                 else if (EQUALS(key, "port")) {
-                    int result = strtol(value, &remain, 10);
-                    if (remain != value && result > 0 && result < 65536)
+                    long result;
+                    if (parse_ranged(value, 1, 65535, &result))
                         app_config.rtsp_port = result;
                 } else if (EQUALS(key, "auth_user"))
                     strncpy(app_config.rtsp_auth_user, value, sizeof(app_config.rtsp_auth_user) - 1);
                 else if (EQUALS(key, "auth_pass"))
                     strncpy(app_config.rtsp_auth_pass, value, sizeof(app_config.rtsp_auth_pass) - 1);
                 else if (EQUALS(key, "audio_codec")) {
-                    /* only the codecs the RTP path implements */
-                    if (EQUALS(value, "pcma") || EQUALS(value, "mp3")) {
+                    if (EQUALS(value, "pcma") || EQUALS(value, "pcmu") || EQUALS(value, "mp3")) {
                         strncpy(app_config.rtsp_audio_codec, value,
                             sizeof(app_config.rtsp_audio_codec) - 1);
                         app_config.rtsp_audio_codec[sizeof(app_config.rtsp_audio_codec) - 1] = 0;
@@ -1245,8 +1226,8 @@ void respond_request(http_request_t *req) {
                 }
             }
         }
-        char escUser[sizeof(app_config.rtsp_auth_user) * 6 + 1];
-        char escCodec[sizeof(app_config.rtsp_audio_codec) * 6 + 1];
+        char esc_user[sizeof(app_config.rtsp_auth_user) * 6 + 1];
+        char esc_codec[sizeof(app_config.rtsp_audio_codec) * 6 + 1];
         respLen = sprintf(response,
             "HTTP/1.1 200 OK\r\n"
             "Content-Type: application/json;charset=UTF-8\r\n"
@@ -1256,8 +1237,8 @@ void respond_request(http_request_t *req) {
             "\"note\":\"port and codec changes apply after restart\"}",
             app_config.rtsp_enable ? "true" : "false", app_config.rtsp_enable_auth ? "true" : "false",
             app_config.rtsp_port,
-            json_str(escUser, sizeof(escUser), app_config.rtsp_auth_user),
-            json_str(escCodec, sizeof(escCodec), app_config.rtsp_audio_codec));
+            escape_json(esc_user, app_config.rtsp_auth_user, sizeof(esc_user)),
+            escape_json(esc_codec, app_config.rtsp_audio_codec, sizeof(esc_codec)));
         send_and_close(req->clntFd, response, respLen);
         return;
     }
@@ -1279,7 +1260,7 @@ void respond_request(http_request_t *req) {
                     strncpy(app_config.onvif_auth_pass, value, sizeof(app_config.onvif_auth_pass) - 1);
             }
         }
-        char escOnvifUser[sizeof(app_config.onvif_auth_user) * 6 + 1];
+        char esc_onvif_user[sizeof(app_config.onvif_auth_user) * 6 + 1];
         respLen = sprintf(response,
             "HTTP/1.1 200 OK\r\n"
             "Content-Type: application/json;charset=UTF-8\r\n"
@@ -1287,7 +1268,7 @@ void respond_request(http_request_t *req) {
             "\r\n"
             "{\"enable\":%s,\"enable_auth\":%s,\"auth_user\":\"%s\",\"note\":\"applies after restart\"}",
             app_config.onvif_enable ? "true" : "false", app_config.onvif_enable_auth ? "true" : "false",
-            json_str(escOnvifUser, sizeof(escOnvifUser), app_config.onvif_auth_user));
+            escape_json(esc_onvif_user, app_config.onvif_auth_user, sizeof(esc_onvif_user)));
         send_and_close(req->clntFd, response, respLen);
         return;
     }

--- a/src/server.h
+++ b/src/server.h
@@ -39,5 +39,6 @@ void send_jpeg_to_client(char index, char *buf, ssize_t size);
 void send_mjpeg_to_client(char index, char *buf, ssize_t size);
 void send_h26x_to_client(char index, hal_vidstream *stream);
 void send_mp3_to_client(char *buf, ssize_t size);
+char http_audio_clients(void);
 void send_mp4_to_client(char index, hal_vidstream *stream, char isH265);
 void send_pcm_to_client(hal_audframe *frame);

--- a/src/server.h
+++ b/src/server.h
@@ -21,6 +21,7 @@
 #include "fmt/mp4.h"
 #include "fmt/nal.h"
 #include "hal/globals.h"
+#include "hal/tools.h"
 #include "hal/types.h"
 #include "jpeg.h"
 #include "media.h"
@@ -39,6 +40,6 @@ void send_jpeg_to_client(char index, char *buf, ssize_t size);
 void send_mjpeg_to_client(char index, char *buf, ssize_t size);
 void send_h26x_to_client(char index, hal_vidstream *stream);
 void send_mp3_to_client(char *buf, ssize_t size);
-char http_audio_clients(void);
+char any_http_audio(void);
 void send_mp4_to_client(char index, hal_vidstream *stream, char isH265);
 void send_pcm_to_client(hal_audframe *frame);


### PR DESCRIPTION
On a small SoC (ARM1176 at 600 MHz) the RTSP sender spent more CPU on `send()` syscalls and on spinning over partial writes than the encoder spent encoding. In Frigate this showed as a stream that lagged and then fast-forwarded.

- **One write per frame.** Interleaved (TCP) packets are staged in a per-connection buffer and flushed once per frame or per 64 KB. A `send()` costs roughly 100 µs here regardless of size, and a frame is many packets.
- **512 KB socket send buffer**, enough to absorb one keyframe. The kernel default (64 KB on these boards) cannot hold one, so the sender spun on `EAGAIN` for as long as the link took to drain — hundreds of ms of CPU per keyframe. `SO_SNDBUFFORCE` with a fallback to `SO_SNDBUF`.
- **`poll()` instead of `usleep(1000)`** on a partial write.
- **One timestamp per frame**, taken from the encoder's capture time. Previously only the marker packet was stamped, so every earlier packet of a frame carried the *previous* frame's time: receivers saw timestamps go backwards within a frame, and players stalled and then raced to catch up. Falls back to send time for HALs that leave the pack timestamp at zero.
- **G.711 A-law (PT 8)** as an alternative to MP3 for RTSP audio, selected by `rtsp.audio_codec`. The SDP now advertises 8000 Hz for PT 0/8 rather than 90000. This also allows the software MP3 encoder — the single most expensive thing on this SoC, ~24 % of a core at 48 kHz — to be skipped entirely when nothing consumes MP3.
- **MP4 muxer**: does not build `moof`/`mdat` when no HTTP client is connected (parameter sets are still cached, so a header is ready on connect), and resets its cached header when the stream configuration changes — without that a codec switch kept sending the old one.
- **`/api/rtsp` and `/api/onvif`** expose those settings, with the matching web UI section.
- **`bitbuf`**: `memcpy` instead of a byte-at-a-time loop.

### Testing

Built for `fh8856v100_lite` (ARMv6). Runs as part of the combined branch this was split from, on three Fullhan FH8856 cameras — RTSP with both MP3 and G.711 audio, ONVIF, MP4 and MJPEG over HTTP. This branch on its own is build-tested, not separately run on hardware.

Sits on top of the four bug fixes in the companion PR; independent of the HAL PR.
